### PR TITLE
Several changes

### DIFF
--- a/community/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
+++ b/community/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
@@ -1,3 +1,5 @@
+{{- if lookup "apps/v1" "DaemonSet" "kube-system" "portworx" }}
+
 {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
 {{- $registrySecret := .Values.registrySecret | default "none" }}
 
@@ -103,3 +105,4 @@ spec:
                      kubectl -n kube-system annotate ServiceMonitor portworx-prometheus-sm helm.sh/resource-policy=keep --overwrite || true;
                      ']
 
+{{- end }}

--- a/community/portworx/templates/serviceaccount-hook.yaml
+++ b/community/portworx/templates/serviceaccount-hook.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: kube-system
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete,post-install"
+    "helm.sh/hook": "pre-delete,post-delete,post-install,pre-upgrade"
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -35,7 +35,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete"
+    "helm.sh/hook": "pre-delete,post-delete,pre-upgrade"
   name: {{ template "px.hookClusterRoleBinding" . }}
 subjects:
   - kind: ServiceAccount

--- a/community/portworx/templates/storage-cluster.yaml
+++ b/community/portworx/templates/storage-cluster.yaml
@@ -42,8 +42,17 @@ metadata:
     portworx.io/pvc-controller: "true"
     {{- end }}
     portworx.io/is-iks: "true"
+    {{- if lookup "apps/v1" "DaemonSet" "kube-system" "portworx" }}
     portworx.io/migration-approved: "false"
+    {{- end }}
     portworx.io/service-type: "portworx-service:NodePort;portworx-api:ClusterIP"
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+
 spec:
   image: portworx/oci-monitor:{{ required "A valid Image tag is required in the SemVer format" .Values.imageVersion }}
   imagePullPolicy: Always
@@ -134,10 +143,8 @@ spec:
           key: "password"
           name: "{{ $etcdSecret }}"
   {{- end }}
-  {{- if eq $csiCloudDrive true }}
-    - name: ENABLE_CSI_DRIVE
-      value: "{{ $csiCloudDrive }}"
-  {{- end }}
+  - name: ENABLE_CSI_DRIVE
+    value: "{{ $csiCloudDrive }}"
   {{- if eq $icrRegistry true }}
     - name: REGISTRY_SECRET
       value: "{{ $icrSecret }}"
@@ -179,11 +186,11 @@ spec:
     enabled: true
   {{- end }}
 
+  {{- with .Values.tolerations }}
   placement:
-    {{- with .Values.tolerations }}
     tolerations:
       {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 
   {{- if not (eq $etcdSecret "none") }}
   volumes:

--- a/community/portworx/templates/storage-cluster.yaml
+++ b/community/portworx/templates/storage-cluster.yaml
@@ -1,4 +1,4 @@
-{{- if or (not (lookup "apps/v1" "DaemonSet" "kube-system" "portworx")) (eq true .Values.generateSTCForMigration) }}
+{{- if or (not (lookup "apps/v1" "DaemonSet" "kube-system" "portworx")) (default true .Values.generateStorageClusterForMigration)) }}
 
   {{- $telemetry := .Values.telemetry | default false }}
   {{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}

--- a/community/portworx/values.yaml
+++ b/community/portworx/values.yaml
@@ -1,8 +1,5 @@
 # Please uncomment and specify values for these options as per your requirements.
 
-generateSTCForMigration: true         # Only used for daemonset to operator migration.
-                                      #   true: generate StorageCluster based on helm parameters.
-                                      #   false: let portworx operator scan daemonset at runtime and auto-generate StorageCluster.
 kvdb:                                 # The KVDB endpoint. Should be in the format etcd:http://<your-kvdb-endpoint>:2379.
                                       # If there are multiple endpoints they need to be ";" seperated.
                                       # the default value is empty since it requires to be explicity set using either the --set option of -f values.yaml.


### PR DESCRIPTION
1. Do not run retain-ds-resource hook when ds is not present
2. add pre-upgrade to service account hook resources
3. do not add migration approval annotation when daemonset is not present
4. add labels to stc for helm managed resource
5. always populate env variable so it wont fail when env is null 
6. do not populate spec.placement when it's empty to prevent failure