### PR TITLE
fix some incorrect values + use latest kubectl when custom registry i…

### DIFF
--- a/community/portworx/templates/_helpers.tpl
+++ b/community/portworx/templates/_helpers.tpl
@@ -20,6 +20,14 @@ productVersion: {{ .Values.imageVersion }}
 {{$version := .Capabilities.KubeVersion.GitVersion | regexFind "^v\\d+\\.\\d+\\.\\d+"}}{{$version}}
 {{- end -}}
 
+{{- define "px.getKubectlVersion" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{$version := .Capabilities.KubeVersion.GitVersion | regexFind "^v\\d+\\.\\d+\\.\\d+"}}{{$version}}
+{{- else -}}
+    {{ "latest" }}
+{{- end -}}
+{{- end -}}
+
 {{- define "px.getETCDPreInstallHookImage" -}}
 {{- if (.Values.customRegistryURL) -}}
     {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}

--- a/community/portworx/templates/hooks/pre-delete/delete-storagecluster.yaml
+++ b/community/portworx/templates/hooks/pre-delete/delete-storagecluster.yaml
@@ -29,7 +29,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: delete-storagecluster
-          image: {{ template "px.getK8KubectlImage" . }}:{{ template "px.kubernetesVersion" . }}
+          image: {{ template "px.getK8KubectlImage" . }}:{{ template "px.getKubectlVersion" . }}
           command: ['/bin/sh',
                     '-c',
                     'kubectl -n kube-system delete storagecluster {{ $clusterName }} --ignore-not-found']

--- a/community/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
+++ b/community/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   {{ if semverCompare ">= 1.8" .Capabilities.KubeVersion.GitVersion }}
   backoffLimit: 0
@@ -34,7 +34,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: retain-px-daemonset
-          image: {{ template "px.getK8KubectlImage" . }}:{{ template "px.kubernetesVersion" . }}
+          image: {{ template "px.getK8KubectlImage" . }}:{{ template "px.getKubectlVersion" . }}
           command: ['/bin/sh',
                     '-c',
                     'kubectl -n kube-system annotate DaemonSet portworx-api helm.sh/resource-policy=keep --overwrite;

--- a/community/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
+++ b/community/portworx/templates/hooks/pre-upgrade/retain-daemonset-install.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   {{ if semverCompare ">= 1.8" .Capabilities.KubeVersion.GitVersion }}
   backoffLimit: 0

--- a/community/portworx/templates/storage-cluster.yaml
+++ b/community/portworx/templates/storage-cluster.yaml
@@ -3,12 +3,12 @@
   {{- $telemetry := .Values.telemetry | default false }}
   {{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
   {{- $etcdEndPoints := .Values.kvdb }}
-  {{- $usefileSystemDrive := .Values.usefileSystemDrive | default false }}
-  {{- $usedrivesAndPartitions := .Values.usedrivesAndPartitions | default false }}
+  {{- $usefileSystemDrive := .Values.storage.usefileSystemDrive | default false }}
+  {{- $usedrivesAndPartitions := .Values.storage.usedrivesAndPartitions | default false }}
   {{- $secretType := .Values.secretType | default "k8s" }}
-  {{- $drives := .Values.drives | default "none" }}
-  {{- $dataInterface := .Values.dataInterface | default "none" }}
-  {{- $managementInterface := .Values.managementInterface | default "none" }}
+  {{- $drives := .Values.storage.drives | default "none" }}
+  {{- $dataInterface := .Values.network.dataInterface | default "none" }}
+  {{- $managementInterface := .Values.network.managementInterface | default "none" }}
   {{- $envVars := .Values.envVars | default "none" }}
   {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
   {{- $registrySecret := .Values.registrySecret | default "none" }}
@@ -96,7 +96,7 @@ spec:
       - {{ $name }}
       {{- end }}
     {{- end }}
-    {{- if $usefileSystemDrive }}
+    {{- if eq $usefileSystemDrive true }}
     forceUseDisks: true
     {{- end }}
     {{- if eq $usedrivesAndPartitions true }}


### PR DESCRIPTION
…s not specified

1. Some kubernetes versions do not have corresponding kubectl version, hence use latest when custom registry is not specified
2. fix some incorrect references to values.yaml